### PR TITLE
Add support for Fennec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,52 @@
 # Simpleperf for geckoview_example
-Scripting to make simpleperf profiling of geckoview_example easier
+Scripting to make simpleperf profiling of Gecko-based Android Apps_example easier
 
-You will need to build your own geckoview_example from source.
-i.e.
-```
-./mach build
-./mach package
-./mach android archive-geckoview
-./mach android build-geckoview_example
-./mach android install-geckoview_example
-```
-This is because simpleperf requires the unstripped shared objects which are not kept as build artifacts.
+You will need to use:
+- either a GeckoView-based vehicle from Mozilla that is both
+*released* (i.e., has had its full symbols published to
+https://symbols.mozilla.org -- generally, Nightly, Beta, or Release)
+and has been *debug signed* (i.e., has been processed by
+`debug_sign_apk.sh` in this repository);
+- or your own `geckoview_example` built from source, i.e., one built
+with ``` ./mach build ./mach android install-geckoview_example ```
+
+This is because simpleperf requires the unstripped shared objects
+which are not part of the published Android packages directly.
 
 ## Setup
-- Clone the latest prebuilt of simpleperf:
-  - ```git clone https://android.googlesource.com/platform/prebuilts/simpleperf```
+- Clone simpleperf:
+  - If you want to use symbols from https://symbols.mozilla.org, make
+    sure you have the commit at the tip of
+    https://github.com/ncalexan/simpleperf/tree/mozilla-symbols, i.e.,
+    with
+    ```git clone https://github.com/ncalexan/simpleperf && git checkout mozilla-symbols```
+  - Otherwise, use the latest prebuilt of simpleperf:
+    ```git clone https://android.googlesource.com/platform/prebuilts/simpleperf```
 
 - Add the helper scripts to your clone of the repo
-  -  [copy_libs.sh](https://github.com/acreskeyMoz/simpleperf_for_geckoview_example/blob/master/copy_libs.sh)
   -  [perf_record.sh](https://github.com/acreskeyMoz/simpleperf_for_geckoview_example/blob/master/perf_record.sh)
 
-- Modify `copy_libs.sh` so that the paths `LOCAL_BUILD_PATH` and `SIMPLEPERF_PATH` match your workspace
+- Modify `perf_record.sh` to refer to the correct android-ndk path for
+  your workspace and to the correct `$TOPOBJDIR` (if building locally).
 
-- Modify `perf_record.sh` to refer to the correct android-ndk path for your workspace
+- If you are targetting a Mozilla-released vehicle, *debug sign* your
+  APK using `debug_sign_apk.sh`.
 
 ## Running
-- run `perf_record.sh` 
+- run `perf_record.sh`
   - This will start simpleperf and then wait for geckoview_example to be started manually.
   - In `perf_record.sh` there are alternative codepaths commented out that will launch geckoview_example first and then start profiling
-
-- Once the capture is complete, you will need to copy your unstripped libraries over by running `copy_libs.sh` (as it is, simpleperf will copy the stripped libs right from the android device)
+- Once the capture is complete, simpleperf will copy libraries for
+  debug info from, in order of preference:
+  1. Your `$TOPOBJDIR` (if that environment variable is set)
+  2. Mozilla's symbol server at https://symbols.mozilla.org (if you're
+  using https://github.com/ncalexan/simpleperf/tree/mozilla-symbols)
+  using
+  3. The device itself -- although these libraries will be unstripped.
   - simpleperf requires the libraries to be in a specific folder relative to the data file. e.g `binary_cache/data/app/org.mozilla.geckoview_example-1/lib/arm/libxul.so`
-  - After running `copy_libs.sh` verify that the libraries you compiled have been copied to the simpleperf `binary_cache` folder for your app.
   - **Depending on the device and app** you may need to manually copy the unstripped libs to the correct `binary_cache` folder,  e.g. ```binary_cache/data/app/org.mozilla.fenix.debug-cGBgD0-yu6fZrNrmK2DHpw==/lib/arm```
   - You can ensure that they are unstripped by running `file` on them, e.g. `file binary_cache/data/app/org.mozilla.geckoview_example-1/lib/arm/libxul.so`
-- **You will need to run `copy_libs.sh` or otherwise ensure that the correct libs are in `binary_cache` _each_ time you capture a profile**
-  
+
 - You can then run `python report_html.py` to generate the html report
 
 - There are additional scripts which can be useful such as the `report.py` or `report_sample.py`.

--- a/debug_sign_apk.sh
+++ b/debug_sign_apk.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Make a release-signed Fennec APK debuggable for `simpleperf`.
+#
+# Run this script in your Gecko topsrcdir, so that
+# [`mobile/android/debug_sign_tool.py`](https://searchfox.org/mozilla-central/source/mobile/android/debug_sign_tool.py)
+# exists.
+#
+# You need to have [`apktool`](https://ibotpeaches.github.io/Apktool/)
+# and the standard Java tools `keytool` and `jarsigner` on your path.
+
+set -x
+
+RELEASE="$1"
+DEBUG="debug_sign_apk.apk"
+
+# First, we need an AndroidManifest.xml with
+# android:debuggable="true".  This is a lot of effort for just that,
+# but it works.
+
+apktool d -f -o debug_sign_apk $RELEASE
+
+apktool b -d debug_sign_apk -o $DEBUG
+
+# Why not just use the APK that apktool produces?  Because all of the
+# resources get processed, which could impact performance.  Better to
+# manually update our original APK "surgically".  This keeps changes
+# to a minimum, including the order of files in the underlying APK.
+
+python mobile/android/debug_sign_tool.py --keytool=`which keytool` --jarsigner=`which jarsigner` $DEBUG
+
+unzip -o $DEBUG AndroidManifest.xml
+unzip -o $DEBUG 'META-INF/*'
+
+mv META-INF/ANDROIDD.SF META-INF/SIGNATURE.SF 
+mv META-INF/ANDROIDD.RSA META-INF/SIGNATURE.RSA
+
+cp $RELEASE $DEBUG
+
+zip $DEBUG -u AndroidManifest.xml
+zip $DEBUG -u META-INF/*
+
+echo "Now 'adb install $DEBUG' and 'adb shell run-as org.mozilla.firefox' to verify android:debuggable=\"true\"."
+
+# Clean up.
+rm -rf AndroidManifest.xml META-INF debug_sign_apk

--- a/perf_record.sh
+++ b/perf_record.sh
@@ -1,20 +1,31 @@
 #!/usr/bin/env bash
 
-# Record a simple perf profile of geckoview_example startup.
-#  -Call to app_profiler.py can be customized with simpleperf options
-#  -Alternatives code paths launch the app just before the capture begins
+set -x
 
-# kill the geckoview processes
-adb shell am force-stop org.mozilla.geckoview_example
+# Record a simple perf profile of vehicle startup.
+#  -Call to app_profiler.py can be customized with simpleperf options
+#  -Alternatives code paths launch the vehicle just before the capture begins
+
+# Fetch unstripped libraries from this directory.
+TOPOBJDIR_ARGS=
+if [ -d "$TOPOBJDIR" ] ; then
+TOPOBJDIR_ARGS=--native_lib_dir $TOPOBJDIR
+fi
+
+PACKAGE=org.mozilla.firefox
+ACTIVITY=org.mozilla.gecko.BrowserApp
+
+# kill the vehicle processes
+adb shell am force-stop $PACKAGE
 
 # optional: fresh profile
-adb shell pm clear org.mozilla.geckoview_example
+adb shell pm clear $PACKAGE
 
-# alternative: launch geckoview just before starting simple perf
-#adb shell 'am start -n org.mozilla.geckoview_example/org.mozilla.geckoview_example.GeckoViewActivity'
+# alternative: launch vehicle just before starting simple perf
+#adb shell "am start -n $PACKAGE/$ACTIVITY"
 
-# alternative: launch geckoview example to a given site
-#adb shell 'am start -n org.mozilla.geckoview_example/org.mozilla.geckoview_example.GeckoViewActivity -a android.intent.action.VIEW -d https://www.google.com'
+# alternative: launch vehicle to a given site
+adb shell "am start -n $PACKAGE/$ACTIVITY -a android.intent.action.VIEW -d 'https://www.google.com'"
 
 # start the simpleperf profile
-python app_profiler.py -p org.mozilla.geckoview_example --ndk_path ~/.mozbuild/android-ndk-r17b -r "-f 1000 -g --duration 5"
+python app_profiler.py -p $PACKAGE --ndk_path ~/.mozbuild/android-ndk-r20 $TOPOBJDIR_ARGS -r "-f 1000 -g --duration 5"

--- a/perf_record_extended.sh
+++ b/perf_record_extended.sh
@@ -6,6 +6,12 @@
 # sh ./perf_record_extended.sh fenix 15 home (profiles automatic startup of fenix)
 # sh ./perf_record_extended.sh fenix 15 https://google.com/ (profiles automatic applink startup of fenix and browsing to google)
 
+# Fetch unstripped libraries from this directory.
+TOPOBJDIR_ARGS=
+if [ -d "$TOPOBJDIR" ] ; then
+TOPOBJDIR_ARGS=--native_lib_dir $TOPOBJDIR
+fi
+
 TARGET=$1
 COLD_START=1
 FRESH_PROFILE=
@@ -22,21 +28,30 @@ fi
 
 if test "$TARGET" == "fenix"; then
     APP=org.mozilla.fenix.performancetest
+elif test "$TARGET" == "fennec"; then
+    APP=org.mozilla.firefox
 else #elif test "$TARGET" == "gve"; then
     APP=org.mozilla.geckoview_example
 fi
 
 if test "$TARGET" == "fenix"; then
     if test -n "$BROWSE_TO"; then
-	ACTIVITY="-a org.mozilla.fenix.IntentReceiverActivity"
-	LAUNCH=1
+        ACTIVITY="-a org.mozilla.fenix.IntentReceiverActivity"
+        LAUNCH=1
     else
-	ACTIVITY="-a org.mozilla.fenix.HomeActivity"
+        ACTIVITY="-a org.mozilla.fenix.HomeActivity"
+    fi
+elif test "$TARGET" == "fennec"; then
+    if test -n "$BROWSE_TO"; then
+        ACTIVITY="-a org.mozilla.gecko.BrowserApp"
+        LAUNCH=1
+    else
+        ACTIVITY="-a org.mozilla.gecko.BrowserApp"
     fi
 else #elif test "$TARGET" == "gve"; then
     if test -n "$BROWSE_TO"; then
-	ACTIVITY="-a org.mozilla.geckoview_example.IntentReceiverActivity"
-	LAUNCH=1
+        ACTIVITY="-a org.mozilla.geckoview_example.IntentReceiverActivity"
+        LAUNCH=1
     else
         ACTIVITY="-a org.mozilla.geckoview_example.GeckoViewActivity"
     fi
@@ -58,7 +73,7 @@ fi
 
 if test -n "$BROWSE_TO"; then
     if test "$BROWSE_TO" != "home"; then
-	EXTRA="--target $BROWSE_TO"
+        EXTRA="--target $BROWSE_TO"
     fi
 else
     ACTIVITY=
@@ -75,7 +90,7 @@ echo BROWSE_TO = $BROWSE_TO
 # This copies native libs with debug syms to the phone for perf
 # note: if you remove -lib after using it, make sure you remove libs in /data/local/tmp/native_libs/*
 # -lib /home/jesup/src/mozilla/inbound_prof/obj-opt/dist/bin
-python app_profiler.py -p $APP $ACTIVITY $EXTRA --ndk_path ~/.mozbuild/android-ndk-r17b  -r "-f 1000 -g --duration $DURATION"
+python app_profiler.py -p $APP $ACTIVITY $EXTRA --ndk_path ~/.mozbuild/android-ndk-r20 $TOPOBJDIR_ARGS -r "-f 1000 -g --duration $DURATION"
 
 # get all the gecko processes (must be running)
 #export PIDS=`adb shell ps | grep org.mozilla | cut -c 14-19`


### PR DESCRIPTION
This adds:
- `debug_sign_apk.sh` for setting `android:debuggable="true"` and debug-signing.
- Instructions for using a `simpleperf` which downloads symbols
published to https://symbols.mozilla.org.
- The `--native_libs_dir` argument that should replace `copy_libs.sh` entirely.
- Presets for Fennec release (org.mozilla.firefox).